### PR TITLE
Added default case for `toChildKeyed` action

### DIFF
--- a/QTRoute.xcodeproj/project.pbxproj
+++ b/QTRoute.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		DC5E921E222B56B3003B7DD1 /* QTRouteResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5E9204222B567D003B7DD1 /* QTRouteResolverTests.swift */; };
 		DC5E921F222B56B8003B7DD1 /* QTRouteDriverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5E9208222B567D003B7DD1 /* QTRouteDriverTests.swift */; };
 		DC5E9220222B56BE003B7DD1 /* BDDTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5E9206222B567D003B7DD1 /* BDDTestHelpers.swift */; };
+		DC70C827222C90E90068CCB6 /* QTRouteResolverActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC70C826222C90E90068CCB6 /* QTRouteResolverActionTests.swift */; };
+		DC70C829222C93050068CCB6 /* QTRouteResolverMergeInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC70C828222C93050068CCB6 /* QTRouteResolverMergeInputTests.swift */; };
 		DCA6DB64222BBC1B0098D765 /* MockQTRouteDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5E91FC222B567D003B7DD1 /* MockQTRouteDriver.swift */; };
 		DCA6DB65222BBC230098D765 /* QTRouteResolverTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC5E9207222B567D003B7DD1 /* QTRouteResolverTestHelpers.swift */; };
 /* End PBXBuildFile section */
@@ -78,6 +80,8 @@
 		DC5E9207222B567D003B7DD1 /* QTRouteResolverTestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QTRouteResolverTestHelpers.swift; sourceTree = "<group>"; };
 		DC5E9208222B567D003B7DD1 /* QTRouteDriverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QTRouteDriverTests.swift; sourceTree = "<group>"; };
 		DC5E9224222B5A3C003B7DD1 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DC70C826222C90E90068CCB6 /* QTRouteResolverActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QTRouteResolverActionTests.swift; sourceTree = "<group>"; };
+		DC70C828222C93050068CCB6 /* QTRouteResolverMergeInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QTRouteResolverMergeInputTests.swift; sourceTree = "<group>"; };
 		DCA6DB63222BA4F00098D765 /* getting-started.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = "getting-started.md"; sourceTree = "<group>"; };
 		DCE8367E2221C32F00E714F8 /* QTRouteTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = QTRouteTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -195,6 +199,8 @@
 				DC5E9201222B567D003B7DD1 /* QTRoutePathTests.swift */,
 				DC5E9208222B567D003B7DD1 /* QTRouteDriverTests.swift */,
 				DC5E9204222B567D003B7DD1 /* QTRouteResolverTests.swift */,
+				DC70C826222C90E90068CCB6 /* QTRouteResolverActionTests.swift */,
+				DC70C828222C93050068CCB6 /* QTRouteResolverMergeInputTests.swift */,
 				DC5E9205222B567D003B7DD1 /* helpers */,
 				DC5E91FB222B567D003B7DD1 /* mocks */,
 			);
@@ -350,7 +356,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DC70C827222C90E90068CCB6 /* QTRouteResolverActionTests.swift in Sources */,
 				DC5E9220222B56BE003B7DD1 /* BDDTestHelpers.swift in Sources */,
+				DC70C829222C93050068CCB6 /* QTRouteResolverMergeInputTests.swift in Sources */,
 				DC5E9219222B56A9003B7DD1 /* MockQTRoutable.swift in Sources */,
 				DCA6DB64222BBC1B0098D765 /* MockQTRouteDriver.swift in Sources */,
 				DC5E921F222B56B8003B7DD1 /* QTRouteDriverTests.swift in Sources */,

--- a/Sources/QTRoute/Resolving/QTRouteResolverAction.swift
+++ b/Sources/QTRoute/Resolving/QTRouteResolverAction.swift
@@ -28,9 +28,11 @@ public extension QTRouteResolver {
             }
         }
 
-        public static func ToChildKeyed(_ actions: [QTRouteId:ActionType.ToChild]) -> ActionType.ToChild {
-            return { to, from, input, animated, completion  in
-                actions[to.id]?(to, from, input, animated, completion)
+        public static func ToChildKeyed(_ actions: [QTRouteId:ActionType.ToChild],
+                                        `default`: ActionType.ToChild? = nil) -> ActionType.ToChild {
+            return {
+                actions[$0.id]?($0, $1, $2, $3, $4)
+                    ?? `default`?($0, $1, $2, $3, $4)
             }
         }
     }

--- a/Sources/QTRoute/Resolving/QTRouteResolving.swift
+++ b/Sources/QTRoute/Resolving/QTRouteResolving.swift
@@ -14,7 +14,7 @@ public protocol QTRouteResolving: class {
 
 public extension QTRouteResolving {
     public func resolveRouteToSelf(from: QTRoutable, input: QTRoutableInput, animated: Bool, completion: @escaping QTRoutableCompletion) {
-        Self.mergeInputDependencies(target: from, input: input)
+        mergeInputDependencies(target: from, input: input)
         completion(from)
     }
 

--- a/Tests/QTRouteTests/QTRouteResolverActionTests.swift
+++ b/Tests/QTRouteTests/QTRouteResolverActionTests.swift
@@ -1,0 +1,144 @@
+
+import XCTest
+import QTRoute
+
+class QTRouteResolverActionTests: XCTestCase {
+
+    var resolver: QTRouteResolver!
+    var stubActions: StubQTResolverActions!
+    var mockRoutable: MockQTRoutable!
+    let route = QTRoute("route")
+
+    override func setUp() {
+        stubActions = StubQTResolverActions()
+    }
+
+    func testResolveRouteToChildKeyed() {
+        given("ToChildKeyed with 2 actions, no default, and some routes") {
+            let route1 = QTRoute("route1")
+            let route2 = QTRoute("route2")
+            let subject = QTRouteResolver.DefaultAction
+                .ToChildKeyed([
+                    route1.id: stubActions.ToChild1(),
+                    route2.id: stubActions.ToChild2()])
+
+            resolver = QTRouteResolver(
+                route1,
+                toChild: subject,
+                toParent: stubActions.ToParent(),
+                toSelf: stubActions.ToSelf())
+            mockRoutable = MockQTRoutable(resolver)
+
+            when("calling resolveRouteToChild for unregistered route") {
+                stubActions.reset()
+                resolver.resolveRouteToChild(QTRoute("route9"),
+                                             from: mockRoutable,
+                                             input: [:],
+                                             animated: false,
+                                             completion: {_ in})
+                then("it should not call either method") {
+                    XCTAssertFalse(stubActions.didCall_ToChild1)
+                    XCTAssertFalse(stubActions.didCall_ToChild2)
+                    XCTAssertFalse(stubActions.didCall_ToParent)
+                    XCTAssertFalse(stubActions.didCall_ToSelf)
+                }
+            }
+
+            when("calling resolveRouteToChild for route 1") {
+                stubActions.reset()
+                resolver.resolveRouteToChild(route1,
+                                             from: mockRoutable,
+                                             input: [:],
+                                             animated: false,
+                                             completion: {_ in})
+                then("it should use the ToChild1 method") {
+                    XCTAssertTrue(stubActions.didCall_ToChild1)
+                    XCTAssertFalse(stubActions.didCall_ToChild2)
+                    XCTAssertFalse(stubActions.didCall_ToParent)
+                    XCTAssertFalse(stubActions.didCall_ToSelf)
+                }
+            }
+
+            when("calling resolveRouteToChild for route 2") {
+                stubActions.reset()
+                resolver.resolveRouteToChild(route2,
+                                             from: mockRoutable,
+                                             input: [:],
+                                             animated: false,
+                                             completion: {_ in})
+                then("it should use the ToChild2 method") {
+                    XCTAssertTrue(stubActions.didCall_ToChild2)
+                    XCTAssertFalse(stubActions.didCall_ToChild1)
+                    XCTAssertFalse(stubActions.didCall_ToParent)
+                    XCTAssertFalse(stubActions.didCall_ToSelf)
+                }
+            }
+        }
+    }
+
+    func testResolveRouteToChildKeyed_default() {
+        given("ToChildKeyed with 2 actions, a default action, and 2 routes") {
+            let route1 = QTRoute("route1")
+            let route2 = QTRoute("route2")
+            let subject = QTRouteResolver.DefaultAction
+                .ToChildKeyed([route1.id: stubActions.ToChild1(),
+                               route2.id: stubActions.ToChild2()],
+                              default: stubActions.ToChild3())
+
+            resolver = QTRouteResolver(
+                route1,
+                toChild: subject,
+                toParent: stubActions.ToParent(),
+                toSelf: stubActions.ToSelf())
+            mockRoutable = MockQTRoutable(resolver)
+
+            when("calling resolveRouteToChild for unregistered route") {
+                stubActions.reset()
+                resolver.resolveRouteToChild(QTRoute("route9"),
+                                             from: mockRoutable,
+                                             input: [:],
+                                             animated: false,
+                                             completion: {_ in})
+                then("it should only call the default route") {
+                    XCTAssertTrue(stubActions.didCall_ToChild3)
+                    XCTAssertFalse(stubActions.didCall_ToChild1)
+                    XCTAssertFalse(stubActions.didCall_ToChild2)
+                    XCTAssertFalse(stubActions.didCall_ToParent)
+                    XCTAssertFalse(stubActions.didCall_ToSelf)
+                }
+            }
+
+            when("calling resolveRouteToChild for route 1") {
+                stubActions.reset()
+                resolver.resolveRouteToChild(route1,
+                                             from: mockRoutable,
+                                             input: [:],
+                                             animated: false,
+                                             completion: {_ in})
+                then("it should use the ToChild1 method") {
+                    XCTAssertTrue(stubActions.didCall_ToChild1)
+                    XCTAssertFalse(stubActions.didCall_ToChild2)
+                    XCTAssertFalse(stubActions.didCall_ToChild3)
+                    XCTAssertFalse(stubActions.didCall_ToParent)
+                    XCTAssertFalse(stubActions.didCall_ToSelf)
+                }
+            }
+
+            when("calling resolveRouteToChild for route 2") {
+                stubActions.reset()
+                resolver.resolveRouteToChild(route2,
+                                             from: mockRoutable,
+                                             input: [:],
+                                             animated: false,
+                                             completion: {_ in})
+                then("it should use the ToChild2 method") {
+                    XCTAssertTrue(stubActions.didCall_ToChild2)
+                    XCTAssertFalse(stubActions.didCall_ToChild1)
+                    XCTAssertFalse(stubActions.didCall_ToChild3)
+                    XCTAssertFalse(stubActions.didCall_ToParent)
+                    XCTAssertFalse(stubActions.didCall_ToSelf)
+                }
+            }
+        }
+    }
+}

--- a/Tests/QTRouteTests/QTRouteResolverMergeInputTests.swift
+++ b/Tests/QTRouteTests/QTRouteResolverMergeInputTests.swift
@@ -1,0 +1,110 @@
+
+import XCTest
+import QTRoute
+
+class QTRouteResolverMergeInputTests: XCTestCase {
+
+    var subject: QTRouteResolver!
+    var stubResolvers: StubQTResolverActions!
+    var mockRoutable: MockQTRoutable!
+    let route = QTRoute("route", dependencies: ["needInput"])
+
+    override func setUp() {
+        stubResolvers = StubQTResolverActions()
+        subject = QTRouteResolver(route,
+                                  toChild: stubResolvers.ToChild1(),
+                                  toParent: stubResolvers.ToParent(),
+                                  toSelf: stubResolvers.ToSelf())
+        mockRoutable = MockQTRoutable(subject)
+    }
+
+    func test_mergeInputDependencies_filter() {
+        given("route with only one dependency ('needInput')") {
+            XCTAssertEqual(route.dependencies, ["needInput"])
+            XCTAssertNil(mockRoutable.routeInput)
+
+            when("calling mergeInputDependencies with more than one input") {
+                subject.mergeInputDependencies(target: mockRoutable,
+                                               input: ["needInput":"stephanie",
+                                                       "noDisassemble":true])
+
+                then("it should only merge the dependent value") {
+                    XCTAssertNotNil(mockRoutable.routeInput)
+                    XCTAssertEqual(mockRoutable.routeInput!.count, 1)
+                    XCTAssertNotNil(mockRoutable.routeInput!["needInput"])
+                    XCTAssertNil(mockRoutable.routeInput!["noDisassemble"])
+                }
+            }
+        }
+    }
+
+    func test_mergeInputDependencies_retain() {
+        given("route with dependencies and some input data already set") {
+            let needyRoute = QTRoute("needy", dependencies:["key1","key2","activator"])
+            subject.route = needyRoute
+            mockRoutable.routeInput = ["key1":"ABC","key2":"123"]
+
+            when("calling mergeInputDependencies with more than one input") {
+                subject.mergeInputDependencies(target: mockRoutable,
+                                               input: ["activator":-1,
+                                                       "key8":"ZYX"])
+
+                then("it should keep existing values and merge the relevant new one") {
+                    XCTAssertNotNil(mockRoutable.routeInput)
+                    XCTAssertEqual(mockRoutable.routeInput!.count, 3)
+                    XCTAssertEqual(mockRoutable.routeInput?["key1"] as? String, "ABC")
+                    XCTAssertEqual(mockRoutable.routeInput?["key2"] as? String, "123")
+                    XCTAssertEqual(mockRoutable.routeInput?["activator"] as? Int, -1)
+                    XCTAssertNil(mockRoutable.routeInput!["key8"])
+                }
+            }
+        }
+    }
+
+    func test_mergeInputDependencies_collision() {
+        given("route with dependencies and some input data already set") {
+            let loadedRoute = QTRoute("loaded", dependencies:["name","address","score"])
+            subject.route = loadedRoute
+            mockRoutable.routeInput = ["name":"Paul",
+                                       "address":"123",
+                                       "score":3]
+
+            when("calling mergeInputDependencies with input that has already been set") {
+
+                subject.mergeInputDependencies(target: mockRoutable, input: ["score":8])
+
+                then("it should update the existing value and not affect the rest") {
+                    XCTAssertNotNil(mockRoutable.routeInput)
+                    XCTAssertEqual(mockRoutable.routeInput!.count, 3)
+                    XCTAssertEqual(mockRoutable.routeInput?["name"] as? String, "Paul")
+                    XCTAssertEqual(mockRoutable.routeInput?["address"] as? String, "123")
+                    XCTAssertEqual(mockRoutable.routeInput?["score"] as? Int, 8)
+                }
+            }
+        }
+    }
+
+    func test_mergeInputDependencies_self() {
+        given("default ToSelf handler, route with dependency") {
+            subject = QTRouteResolver(route,
+                                      toChild: QTRouteResolver.DefaultAction.ToChildNoOp(),
+                                      toParent: QTRouteResolver.DefaultAction.ToParentNoOp(),
+                                      toSelf: QTRouteResolver.DefaultAction.ToSelf())
+            mockRoutable.routeResolver = subject
+            XCTAssertEqual(route.dependencies, ["needInput"])
+            XCTAssertNil(mockRoutable.routeInput)
+
+            when("calling resolveRouteToSelf") {
+                subject.resolveRouteToSelf(from: mockRoutable,
+                                           input: ["needInput":"confirm"],
+                                           animated: false,
+                                           completion: {_ in})
+
+                then("it should have merged the input") {
+                    XCTAssertNotNil(mockRoutable.routeInput)
+                    XCTAssertEqual(mockRoutable.routeInput?["needInput"] as? String, "confirm")
+                }
+            }
+        }
+    }
+}

--- a/Tests/QTRouteTests/QTRouteResolverTests.swift
+++ b/Tests/QTRouteTests/QTRouteResolverTests.swift
@@ -7,7 +7,7 @@ class QTRouteResolverTests: XCTestCase {
     var subject: QTRouteResolver!
     var stubResolvers: StubQTResolverActions!
     var mockRoutable: MockQTRoutable!
-    let route = QTRoute("route", dependencies: ["needInput"])
+    let route = QTRoute("route")
 
     override func setUp() {
         stubResolvers = StubQTResolverActions()
@@ -55,127 +55,34 @@ class QTRouteResolverTests: XCTestCase {
         }
     }
 
-    func testResolveRouteToChildKeyed() {
-        given("keyed actions and a couple routes") {
-            let route1 = QTRoute("route1")
-            let route2 = QTRoute("route2")
-            subject = QTRouteResolver(
-                route1,
-                toChild: QTRouteResolver
-                    .DefaultAction.ToChildKeyed([
-                        route1.id: stubResolvers.ToChild1(),
-                        route2.id: stubResolvers.ToChild2()
-                        ]),
-                toParent: stubResolvers.ToParent(),
-                toSelf: stubResolvers.ToSelf())
-            mockRoutable = MockQTRoutable(subject)
+    func testResolveRouteToSelf_defaultImplementation() {
+        given("subject inherits default implementation") {
+            let defaultImpl = DefaultImplementationResolver()
+            mockRoutable.routeResolver = defaultImpl
 
-            when("calling resolveRouteToChild for unregistered route") {
-                stubResolvers.reset()
-                subject.resolveRouteToChild(QTRoute("route9"),
-                                            from: mockRoutable,
-                                            input: [:],
-                                            animated: false,
-                                            completion: {_ in})
-                then("it should not call either method") {
-                    XCTAssertFalse(stubResolvers.didCall_ToChild1)
-                    XCTAssertFalse(stubResolvers.didCall_ToChild2)
-                }
-            }
-
-            when("calling resolveRouteToChild for route 1") {
-                stubResolvers.reset()
-                subject.resolveRouteToChild(route1,
-                                            from: mockRoutable,
-                                            input: [:],
-                                            animated: false,
-                                            completion: {_ in})
-                then("it should use the ToChild1 method") {
-                    XCTAssertTrue(stubResolvers.didCall_ToChild1)
-                    XCTAssertFalse(stubResolvers.didCall_ToChild2)
-                }
-            }
-
-            when("calling resolveRouteToChild for route 2") {
-                stubResolvers.reset()
-                subject.resolveRouteToChild(route2,
-                                            from: mockRoutable,
-                                            input: [:],
-                                            animated: false,
-                                            completion: {_ in})
-                then("it should use the ToChild2 method") {
-                    XCTAssertTrue(stubResolvers.didCall_ToChild2)
-                    XCTAssertFalse(stubResolvers.didCall_ToChild1)
-                }
-            }
-        }
-    }
-
-    func test_mergeInputDependencies_filter() {
-        given("route with only one dependency ('needInput')") {
-            XCTAssertEqual(route.dependencies, ["needInput"])
-            XCTAssertNil(mockRoutable.routeInput)
-
-            when("calling mergeInputDependencies with more than one input") {
-                subject.mergeInputDependencies(target: mockRoutable,
-                                               input: ["needInput":"stephanie",
-                                                       "noDisassemble":true])
-
-                then("it should only merge the dependent value") {
-                    XCTAssertNotNil(mockRoutable.routeInput)
-                    XCTAssertEqual(mockRoutable.routeInput!.count, 1)
-                    XCTAssertNotNil(mockRoutable.routeInput!["needInput"])
-                    XCTAssertNil(mockRoutable.routeInput!["noDisassemble"])
-                }
-            }
-        }
-    }
-
-    func test_mergeInputDependencies_retain() {
-        given("route with dependencies and some input data already set") {
-            let needyRoute = QTRoute("needy", dependencies:["key1","key2","activator"])
-            subject.route = needyRoute
-            mockRoutable.routeInput = ["key1":"ABC","key2":"123"]
-
-            when("calling mergeInputDependencies with more than one input") {
-                subject.mergeInputDependencies(target: mockRoutable,
-                                               input: ["activator":-1,
-                                                       "key8":"ZYX"])
-
-                then("it should keep existing values and merge the relevant new one") {
-                    XCTAssertNotNil(mockRoutable.routeInput)
-                    XCTAssertEqual(mockRoutable.routeInput!.count, 3)
-                    XCTAssertEqual(mockRoutable.routeInput?["key1"] as? String, "ABC")
-                    XCTAssertEqual(mockRoutable.routeInput?["key2"] as? String, "123")
-                    XCTAssertEqual(mockRoutable.routeInput?["activator"] as? Int, -1)
-                    XCTAssertNil(mockRoutable.routeInput!["key8"])
-                }
-            }
-        }
-    }
-
-    func test_mergeInputDependencies_self() {
-        given("route with dependency") {
-            XCTAssertEqual(route.dependencies, ["needInput"])
-            XCTAssertNil(mockRoutable.routeInput)
-
-            when("calling resolveRouteToSelf against default ToSelf handler") {
-                let defaultImpl = QTRouteResolver(route,
-                                                  toChild: QTRouteResolver.DefaultAction.ToChildNoOp(),
-                                                  toParent: QTRouteResolver.DefaultAction.ToParentNoOp(),
-                                                  toSelf: QTRouteResolver.DefaultAction.ToSelf())
-                mockRoutable.routeResolver = defaultImpl
+            when("calling resolveRouteToSelf") {
+                let (captured, comletion) = captureRoutableCompletion()
 
                 defaultImpl.resolveRouteToSelf(from: mockRoutable,
-                                               input: ["needInput":"confirm"],
+                                               input: ["number":9],
                                                animated: false,
-                                               completion: {_ in})
+                                               completion: comletion)
 
-                then("it should have merged the input") {
-                    XCTAssertNotNil(mockRoutable.routeInput)
-                    XCTAssertEqual(mockRoutable.routeInput?["needInput"] as? String, "confirm")
+                then("it should call completion passing the soure routable with merged dependencies") {
+                    XCTAssert(captured.value === mockRoutable)
+                    XCTAssertEqual(captured.value?.routeInput?["number"] as? Int, 9)
                 }
             }
         }
+    }
+
+    private class DefaultImplementationResolver: QTRouteResolving {
+        var route: QTRoute = QTRoute("A", dependencies: ["number"])
+        func resolveRouteToChild(_ route: QTRoute, from: QTRoutable, input: QTRoutableInput,
+                                 animated: Bool,
+                                 completion: @escaping QTRoutableCompletion) { /**/ }
+        func resolveRouteToParent(from: QTRoutable, input: QTRoutableInput,
+                                  animated: Bool,
+                                  completion: @escaping QTRoutableCompletion) { /**/ }
     }
 }

--- a/Tests/QTRouteTests/mocks/StubQTResolverActions.swift
+++ b/Tests/QTRouteTests/mocks/StubQTResolverActions.swift
@@ -5,6 +5,7 @@ public class StubQTResolverActions {
     func reset() {
         didCall_ToChild1 = false
         didCall_ToChild2 = false
+        didCall_ToChild3 = false
         didCall_ToParent = false
         didCall_ToSelf = false
     }
@@ -20,6 +21,13 @@ public class StubQTResolverActions {
     public func ToChild2() -> QTRouteResolver.ActionType.ToChild {
         return { [weak self] _, _, _, _, _ in
             self?.didCall_ToChild2 = true
+        }
+    }
+
+    public var didCall_ToChild3 = false
+    public func ToChild3() -> QTRouteResolver.ActionType.ToChild {
+        return { [weak self] _, _, _, _, _ in
+            self?.didCall_ToChild3 = true
         }
     }
 


### PR DESCRIPTION
When composing using the built-in resolver's `ToChildKeyed` action, it needs a way to offer a default action for when none of the registered ones match the target route.